### PR TITLE
RPT-3728: Initial Next.js Setup

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@sutech-jp:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "raas-next-sample",
       "version": "0.1.0",
       "dependencies": {
+        "@sutech-jp/raas-client-for-typescript": "^0.2.0",
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -952,6 +953,11 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sutech-jp/raas-client-for-typescript": {
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@sutech-jp/raas-client-for-typescript/0.2.0/7f13600d5db17573fadbdad4830d3eff0fb4a769",
+      "integrity": "sha512-xyC2wE6D4QKVQ+80aNk3aM3KYJj34raLlJLeXiQ5BdDHKbtLomKWpDJE+yz0pKNtKtnYkEEPBGoG7SA1a109kw=="
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -3,25 +3,26 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
+    "@sutech-jp/raas-client-for-typescript": "^0.2.0",
+    "next": "15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "next": "15.3.2"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/api/hello/route.ts
+++ b/src/app/api/hello/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function PUT(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  return handleRequest(request);
+}
+
+export async function PATCH(request: NextRequest) {
+  return handleRequest(request);
+}
+
+interface SpecialRouteHandler {
+  matches(path: string): boolean;
+  handle(request: NextRequest): Promise<NextResponse>;
+}
+
+class SessionRouteHandler implements SpecialRouteHandler {
+  matches(path: string): boolean {
+    return path === '/api/hello/session';
+  }
+
+  async handle(request: NextRequest): Promise<NextResponse> {
+    const token = request.headers.get('token');
+    return NextResponse.json({ token });
+  }
+}
+
+const specialRouteHandlers: SpecialRouteHandler[] = [
+  new SessionRouteHandler(),
+];
+
+async function handleRequest(request: NextRequest) {
+  const path = request.nextUrl.pathname;
+  
+  for (const handler of specialRouteHandlers) {
+    if (handler.matches(path)) {
+      return handler.handle(request);
+    }
+  }
+  
+  let body = null;
+  try {
+    body = await request.json();
+  } catch (e) {
+  }
+  
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  
+  const method = request.method;
+  
+  const queryParams: Record<string, string> = {};
+  request.nextUrl.searchParams.forEach((value, key) => {
+    queryParams[key] = value;
+  });
+  
+  return NextResponse.json({
+    message: 'Hello from the API',
+    path,
+    method,
+    body,
+    headers,
+    queryParams,
+    timestamp: new Date().toISOString()
+  });
+}

--- a/src/app/api/hello/session/route.ts
+++ b/src/app/api/hello/session/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  return handleSessionRequest(request);
+}
+
+export async function POST(request: NextRequest) {
+  return handleSessionRequest(request);
+}
+
+export async function PUT(request: NextRequest) {
+  return handleSessionRequest(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  return handleSessionRequest(request);
+}
+
+export async function PATCH(request: NextRequest) {
+  return handleSessionRequest(request);
+}
+
+async function handleSessionRequest(request: NextRequest) {
+  const token = request.headers.get('token');
+  return NextResponse.json({ token });
+}


### PR DESCRIPTION
# RPT-3728: Initial Next.js Setup

This PR sets up an empty Next.js project with the name "raas-next-sample" that will be deployed on Vercel.

## Changes
- Created a new Next.js project with TypeScript, ESLint, and Tailwind CSS
- Added a simple API route to demonstrate backend functionality
- Added .npmrc file for GitHub package registry configuration
- Added raas-client-for-typescript as a dependency
- Verified the application runs correctly locally

## Testing
- Verified the frontend is accessible locally
- Verified the API endpoint returns the expected response
- Verified the raas-client-for-typescript dependency is properly installed

Link to Devin run: https://app.devin.ai/sessions/8288185234584226ba94653022be740d
Requested by: Sunao Suzuki (sunao@sutech.co.jp)
