### PR TITLE
RPT-3728: Migrate frontend from sample_fe_vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "raas-next-sample",
       "version": "0.1.0",
       "dependencies": {
+        "@sutech-jp/datatraveler-react-client": "^0.1.17",
         "@sutech-jp/raas-client-for-typescript": "^0.2.0",
+        "@sutech-jp/raas-react-client": "^0.1.20",
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -954,10 +956,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sutech-jp/datatraveler-react-client": {
+      "version": "0.1.17",
+      "resolved": "https://npm.pkg.github.com/download/@sutech-jp/datatraveler-react-client/0.1.17/c42f4651f3aade9ef0d03ec951863cac05322796",
+      "integrity": "sha512-beysPKckiekDymccO1qa3PCH2bIX5GIp6mspntjm2welxgU8nOfr7VjRGzoDRSrsNNqvNUWlw4rMmZLlZGejXQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@sutech-jp/raas-client-for-typescript": {
       "version": "0.2.0",
       "resolved": "https://npm.pkg.github.com/download/@sutech-jp/raas-client-for-typescript/0.2.0/7f13600d5db17573fadbdad4830d3eff0fb4a769",
       "integrity": "sha512-xyC2wE6D4QKVQ+80aNk3aM3KYJj34raLlJLeXiQ5BdDHKbtLomKWpDJE+yz0pKNtKtnYkEEPBGoG7SA1a109kw=="
+    },
+    "node_modules/@sutech-jp/raas-react-client": {
+      "version": "0.1.20",
+      "resolved": "https://npm.pkg.github.com/download/@sutech-jp/raas-react-client/0.1.20/8a22c21c005f42efc17e339494ff58d07f77a993",
+      "integrity": "sha512-XQSLwzLbO9GBdEZYLpL4/6XZBDd4D9aGj/DZLK6rOy4wfV9Sjku4DGqsEGdR8J7HJT7PSM4er4f7REUWLX2Fjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@sutech-jp/datatraveler-react-client": "^0.1.17",
     "@sutech-jp/raas-client-for-typescript": "^0.2.0",
+    "@sutech-jp/raas-react-client": "^0.1.20",
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,130 @@
+import { Session } from '@sutech-jp/raas-react-client'
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL
+
+export const deleteTenant = async () => {
+  await fetch(BACKEND_URL + `/raas/tenant/delete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+export const createImportSession = async (): Promise<Session> => {
+  return await createDataTravelerSession(`/import`)
+}
+
+export const createGallerySession = async (application: string, schema: string): Promise<Session> => {
+  return await createReportSession(`/gallery/${application}/${schema}`)
+}
+
+export const createDesignerNewSession = async (application: string, schema: string): Promise<Session> => {
+  return await createReportSession(`/designer/create/${application}/${schema}`)
+}
+
+export const createDesignerEditSession = async (layoutId: string): Promise<Session> => {
+  return await createReportSession(`/designer/${layoutId}`)
+}
+
+export const createDictionarySession = async (): Promise<Session> => {
+  return await createReportSession(`/tenantInfo`)
+}
+
+export const createOrganizerSession = async (application: string, schema: string): Promise<Session> => {
+  return await createReportSession(`/organizer/${application}/${schema}`)
+}
+
+export const createLogoSession = async (): Promise<Session> => {
+  return await createReportSession(`/config`)
+}
+
+const createDataTravelerSession = async (subUrl: string): Promise<Session> => {
+  return createRaasSession('datatraveler', subUrl)
+}
+
+const createReportSession = async (subUrl: string): Promise<Session> => {
+  return createRaasSession('report', subUrl)
+}
+
+const createRaasSession = async (msa: 'datatraveler' | 'report', subUrl: string): Promise<Session> => {
+  return await fetch(BACKEND_URL + `/raas/${msa}/session`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      subUrl,
+      backUrl: typeof window !== 'undefined' ? window.location.href : '',
+    }),
+  }).then((res) => res.json())
+}
+
+export const getResult = async (dataImportId: string): Promise<Result> => {
+  return await fetch(BACKEND_URL + `/raas/report/result/${dataImportId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json())
+}
+
+export type RptLayout = { id: number; name: string }
+
+export const getRaasLayouts = async (application: string, schema: string): Promise<RptLayout[]> => {
+  return await fetch(BACKEND_URL + `/raas/report/layout/${application}/${schema}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json())
+}
+
+export type Result = {
+  id: string
+  status: string
+
+  details: { dataId: string; pdfUrl: string }[]
+}
+
+export type MockPartner = {
+  code: string
+  name: string
+  zipcode: string
+  address1: string
+  address2: string
+  address3: string
+}
+
+export const loadMockPartners = async (): Promise<MockPartner[]> => {
+  return [
+    {
+      code: 'sample_code',
+      name: 'sample_name',
+      zipcode: 'sample_zipcode',
+      address1: 'sample_address1',
+      address2: 'sample_address2',
+      address3: 'sample_address3',
+    },
+  ]
+}
+
+export type MockCompany = {
+  code: string
+  name: string
+  zipcode: string
+  address1: string
+  address2: string
+  address3: string
+}
+
+export const loadMockCompany = async (): Promise<MockCompany> => {
+  return {
+    code: 'sample_code',
+    name: 'sample_name',
+    zipcode: 'sample_zipcode',
+    address1: 'sample_address1',
+    address2: 'sample_address2',
+    address3: 'sample_address3',
+  }
+}

--- a/src/app/designer/edit/[layoutId]/page.tsx
+++ b/src/app/designer/edit/[layoutId]/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import React from 'react'
+import { ReportDesigner, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createDesignerEditSession } from '../../../../api'
+import { useParams } from 'next/navigation'
+import { HEIGHT_OFFSET } from '../../../../constants'
+import { customStyles } from '../../../../themes/customTheme'
+
+export default function DesignerEditPage() {
+  const params = useParams()
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    if (params.layoutId) {
+      createDesignerEditSession(params.layoutId as string).then(setSession)
+    }
+  }, [params.layoutId])
+
+  if (!params.layoutId) return <div>Layout ID is required</div>
+  
+  return (
+    <ReportDesigner
+      session={session}
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/designer/gallery/page.tsx
+++ b/src/app/designer/gallery/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import React from 'react'
+import { ReportLayoutGallery, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createGallerySession } from '../../../api'
+import { APPLICATION, HEIGHT_OFFSET, SCHEMA } from '../../../constants'
+import { useRouter } from 'next/navigation'
+import { customStyles } from '../../../themes/customTheme'
+
+export default function DesignerGalleryPage() {
+  const router = useRouter()
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createGallerySession(APPLICATION, SCHEMA).then(setSession)
+  }, [])
+
+  const onCreateLayout = () => router.push('/designer/new')
+  const onEditLayout = (layoutId: number) => router.push(`/designer/edit/${layoutId}`)
+  
+  return (
+    <ReportLayoutGallery
+      session={session}
+      onCreateLayout={onCreateLayout}
+      onEditLayout={onEditLayout}
+      deletable
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/designer/new/page.tsx
+++ b/src/app/designer/new/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React from 'react'
+import { ReportDesigner, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createDesignerNewSession } from '../../../api'
+import { APPLICATION, HEIGHT_OFFSET, SCHEMA } from '../../../constants'
+import { customStyles } from '../../../themes/customTheme'
+
+export default function DesignerNewPage() {
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createDesignerNewSession(APPLICATION, SCHEMA).then(setSession)
+  }, [])
+
+  return (
+    <ReportDesigner
+      session={session}
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/dictionary/page.tsx
+++ b/src/app/dictionary/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React from 'react'
+import { ReportTenantInfo, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createDictionarySession } from '../../api'
+import { HEIGHT_OFFSET } from '../../constants'
+import { customStyles } from '../../themes/customTheme'
+
+export default function DictionaryPage() {
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createDictionarySession().then(setSession)
+  }, [])
+
+  return (
+    <ReportTenantInfo
+      session={session}
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/import/[layoutId]/page.tsx
+++ b/src/app/import/[layoutId]/page.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import React from 'react'
+import { DataTravelerImport, DataTravelerResult, MapperDef, Session } from '@sutech-jp/datatraveler-react-client'
+import { useEffect, useState } from 'react'
+import { MockCompany, MockPartner, createImportSession, loadMockCompany, loadMockPartners } from '../../../api'
+import { useRouter, useParams } from 'next/navigation'
+import { APPLICATION, HEIGHT_OFFSET, SCHEMA } from '../../../constants'
+import { useWindowSize } from '../../../hooks/useWindowSize'
+import { customStyles } from '../../../themes/customTheme'
+
+export default function ImportPage() {
+  const params = useParams()
+  const router = useRouter()
+  const [, height] = useWindowSize()
+  const [session, setSession] = useState<Session>()
+
+  const [partners, setPartners] = useState<MockPartner[]>()
+  const [company, setCompany] = useState<MockCompany>()
+
+  useEffect(() => {
+    createImportSession().then(setSession)
+    loadMockPartners().then(setPartners)
+    loadMockCompany().then(setCompany)
+  }, [])
+
+  const onImport = (result: DataTravelerResult) => {
+    console.log(result)
+    router.push(`/result/${result.dataImportLogId}`)
+  }
+
+  const onCancel = () => router.push('/import/gallery')
+
+  if (!params.layoutId) return <></>
+  if (!partners) return <div>Loading partners...</div>
+  if (!company) return <div>Loading company...</div>
+  
+  return (
+    <DataTravelerImport
+      session={session}
+      report={{ layoutId: Number(params.layoutId), application: APPLICATION, schema: SCHEMA, reportStep: 'preview' }}
+      application={APPLICATION}
+      schema={SCHEMA}
+      mapper={{ sample_partners: partners }}
+      binder={{ sample_company: company }}
+      mapperDefs={[samplePartnersMapperDef]}
+      binderDefs={[sampleCompanyMapperDef]}
+      onImport={onImport}
+      onCancel={onCancel}
+      height={height - HEIGHT_OFFSET}
+      customStyles={customStyles}
+    />
+  )
+}
+
+const sampleCompanyMapperDef: MapperDef = {
+  name: 'sample_company',
+  caption: '会社情報',
+  values: [
+    { path: 'code', caption: '会社コード' },
+    { path: 'name', caption: '会社名' },
+    { path: 'zipcode', caption: '郵便番号' },
+    { path: 'address1', caption: '住所１' },
+    { path: 'address2', caption: '住所２' },
+    { path: 'address3', caption: '住所３' },
+  ],
+}
+
+const samplePartnersMapperDef: MapperDef = {
+  name: 'sample_partners',
+  caption: '取引先情報',
+  values: [
+    { path: 'code', caption: '取引先コード' },
+    { path: 'name', caption: '取引先名' },
+    { path: 'zipcode', caption: '郵便番号' },
+    { path: 'address1', caption: '住所１' },
+    { path: 'address2', caption: '住所２' },
+    { path: 'address3', caption: '住所３' },
+  ],
+}

--- a/src/app/import/gallery/page.tsx
+++ b/src/app/import/gallery/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import React from 'react'
+import { ReportLayoutGallery, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createGallerySession } from '../../../api'
+import { APPLICATION, HEIGHT_OFFSET, SCHEMA } from '../../../constants'
+import { useRouter } from 'next/navigation'
+import { customStyles } from '../../../themes/customTheme'
+
+export default function ImportGalleryPage() {
+  const router = useRouter()
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createGallerySession(APPLICATION, SCHEMA).then(setSession)
+  }, [])
+
+  const onCreateLayout = () => router.push('/designer/new')
+  const onEditLayout = (layoutId: number) => router.push(`/designer/edit/${layoutId}`)
+  
+  return (
+    <ReportLayoutGallery
+      session={session}
+      onCreateLayout={onCreateLayout}
+      onEditLayout={onEditLayout}
+      deletable
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/import/select/page.tsx
+++ b/src/app/import/select/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { RptLayout, getRaasLayouts } from '../../../api'
+import { APPLICATION, SCHEMA } from '../../../constants'
+
+export default function ImportSelectLayoutsPage() {
+  const router = useRouter()
+  const [layouts, setLayouts] = useState<RptLayout[]>([])
+
+  useEffect(() => {
+    getRaasLayouts(APPLICATION, SCHEMA).then(setLayouts)
+  }, [])
+
+  return (
+    <div className="p-5">
+      <h1 className="text-2xl font-bold mb-4">インポート用レイアウト選択</h1>
+      <ul className="list-none p-0">
+        {layouts.map((layout) => (
+          <li key={layout.id} className="my-2">
+            <button 
+              onClick={() => router.push(`/import/${layout.id}`)}
+              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+            >
+              {layout.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/logo/page.tsx
+++ b/src/app/logo/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React from 'react'
+import { ReportConfig, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createLogoSession } from '../../api'
+import { HEIGHT_OFFSET } from '../../constants'
+import { customStyles } from '../../themes/customTheme'
+
+export default function LogoPage() {
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createLogoSession().then(setSession)
+  }, [])
+
+  return (
+    <ReportConfig
+      session={session}
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/organizer/page.tsx
+++ b/src/app/organizer/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import React from 'react'
+import { ReportOrganizer, Session } from '@sutech-jp/raas-react-client'
+import { useEffect, useState } from 'react'
+import { createOrganizerSession } from '../../api'
+import { ORGANIZER_APPLICATION, HEIGHT_OFFSET, ORGANIZER_SCHEMA } from '../../constants'
+import { customStyles } from '../../themes/customTheme'
+
+export default function OrganizerPage() {
+  const [session, setSession] = useState<Session>()
+
+  useEffect(() => {
+    createOrganizerSession(ORGANIZER_APPLICATION, ORGANIZER_SCHEMA).then(setSession)
+  }, [])
+
+  return (
+    <ReportOrganizer
+      session={session}
+      height={`calc(100vh - ${HEIGHT_OFFSET}px)`}
+      customStyles={customStyles}
+    />
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,40 @@
-import Image from "next/image";
+'use client'
+
+import Link from 'next/link'
+import { deleteTenant } from '../api'
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+    <div className="p-5">
+      <h1 className="text-2xl font-bold mb-4">Next.js + React + TS Raas Sample</h1>
+      <ul className="list-none p-0">
+        <li className="my-2">
+          <Link href="/import/gallery" className="text-blue-600 hover:underline">インポート(ギャラリー)</Link>
+        </li>
+        <li className="my-2">
+          <Link href="/import/select" className="text-blue-600 hover:underline">インポート(Select)</Link>
+        </li>
+        <li className="my-2">
+          <Link href="/designer/gallery" className="text-blue-600 hover:underline">レイアウト設定</Link>
+        </li>
+        <li className="my-2">
+          <Link href="/organizer" className="text-blue-600 hover:underline">PDF分割</Link>
+        </li>
+        <li className="my-2">
+          <Link href="/dictionary" className="text-blue-600 hover:underline">ユーザー辞書</Link>
+        </li>
+        <li className="my-2">
+          <Link href="/logo" className="text-blue-600 hover:underline">ロゴ・社印</Link>
+        </li>
+        <li className="my-2">
+          <button 
+            onClick={deleteTenant}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+            テナント削除
+          </button>
+        </li>
+      </ul>
     </div>
-  );
+  )
 }

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React from 'react'
+import { useEffect, useState } from 'react'
+import { Result, getResult } from '../../../api'
+import { useParams } from 'next/navigation'
+
+export default function ResultPage() {
+  const params = useParams()
+  const [result, setResult] = useState<Result>()
+
+  useEffect(() => {
+    if (params.id) {
+      getResult(params.id as string).then(setResult)
+    }
+  }, [params.id])
+
+  if (!result) return <div className="p-5">Loading...</div>
+
+  return (
+    <div className="p-5">
+      <h1 className="text-2xl font-bold mb-4">結果</h1>
+      <div className="mb-2">ID: {result.id}</div>
+      <div className="mb-4">ステータス: {result.status}</div>
+      <h2 className="text-xl font-bold mb-2">詳細</h2>
+      <ul className="list-none p-0">
+        {result.details.map((detail, index) => (
+          <li key={index} className="mb-4 p-4 border border-gray-200 rounded">
+            <div className="mb-2">データID: {detail.dataId}</div>
+            <div>
+              PDF: <a href={detail.pdfUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">表示</a>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,6 @@
+export const APPLICATION = 'tutorial'
+export const SCHEMA = 'invoice'
+export const HEIGHT_OFFSET = 25
+
+export const ORGANIZER_APPLICATION = 'sample'
+export const ORGANIZER_SCHEMA = 'invoice'

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useState, useLayoutEffect } from 'react'
+
+export const useWindowSize = (): number[] => {
+  const [size, setSize] = useState([0, 0])
+
+  useLayoutEffect(() => {
+    const updateSize = (): void => {
+      setSize([window.innerWidth, window.innerHeight])
+    }
+
+    window.addEventListener('resize', updateSize)
+    updateSize()
+
+    return () => window.removeEventListener('resize', updateSize)
+  }, [])
+
+  return size
+}

--- a/src/themes/customTheme.ts
+++ b/src/themes/customTheme.ts
@@ -1,0 +1,97 @@
+import { ThemeOptions } from "@sutech-jp/raas-react-client";
+
+/**
+ * Theme options that can be applied to RaaS components as "Custom Styles".
+ * To apply the styles, set it to "customStyles" attribute of each component.
+ * 
+ * e.g.) <ReportLayoutGallery customStyles={customStyles} {...restProps} />
+ * 
+ * Following definition is same as the styles provided by RaaS UI System.
+ * Change the properties as you want to overwrite.
+ */
+export const customStyles: ThemeOptions = {
+  palette: {
+    primary: {
+      light: '#E9F2FB',
+      soft: '#6DA9E5',
+      main: '#1B6FD3',
+      dark: '#1659A9',
+    },
+    secondary: {
+      light: '#EFF1F5',
+      soft: '#D5DAE4',
+      main: '#BABFCA',
+      dark: '#4B5361',
+    },
+    info: {
+      light: '#E9F2FB',
+      soft: '#6DA9E5',
+      main: '#1B6FD3',
+      dark: '#1659A9',
+    },
+    success: {
+      light: '#EAF8F4',
+      soft: '#75C8AB',
+      main: '#189F71',
+      dark: '#26835C',
+    },
+    warning: {
+      light: '#FFF5EA',
+      soft: '#F6B471',
+      main: '#E27822',
+      dark: '#BF671E',
+    },
+    error: {
+      light: '#FEEFF1',
+      soft: '#E5949D',
+      main: '#D34C5C',
+      dark: '#A93D4A',
+    },
+    grey: {
+      '50': '#EFF1F5',
+      '100': '#D5DAE4',
+      '200': '#BABFCA',
+      '300': '#9FA4AF',
+      '400': '#838995',
+      '500': '#686E7A',
+      '600': '#5A606E',
+      '700': '#4B5361',
+      '800': '#3D4555',
+      '900': '#2E3748',
+      A100: '#D5DAE4',
+      A200: '#BABFCA',
+      A400: '#838995',
+      A700: '#4B5361',
+    }
+  },
+  typography: {
+    pageTitle: { fontSize: '1.25rem', fontWeight: 700, lineHeight: 1.2, color: '#333333' },
+    dialogTitle: { fontSize: '1.25rem', fontWeight: 400, lineHeight: 1.2, color: '#333333' },
+    subheadM: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.2, color: '#333333' },
+    subheadL: { fontSize: '1rem', fontWeight: 700, lineHeight: 1.2, color: '#333333' },
+    textNormal: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#333333' },
+    textStrong: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.5, color: '#333333' },
+    textSupplement: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#7f7f7f' },
+    textHint: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#AAAAAA' },
+    labelNormal: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.2, color: '#7f7f7f' },
+    labelError: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.2, color: '#D34C5C' },
+    labelSmall: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#7f7f7f' },
+    labelSmallActive: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#1B6FD3' },
+    labelSmallError: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#D34C5C' },
+    textPrimary: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#1B6FD3' },
+    textStrongPrimary: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.5, color: '#1B6FD3' },
+    textError: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#D34C5C' },
+    textStrongError: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.5, color: '#D34C5C' },
+    textWarning: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#E27822' },
+    textStrongWarning: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.5, color: '#E27822' },
+    textSuccess: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#189F71' },
+    textStrongSuccess: { fontSize: '0.875rem', fontWeight: 700, lineHeight: 1.5, color: '#189F71' },
+    textWhite: { fontSize: '0.875rem', fontWeight: 400, lineHeight: 1.5, color: '#FFFFFF' },
+    groupHeader: { fontSize: '0.75rem', fontWeight: 700, lineHeight: 1.2, color: '#7f7f7f' },
+    caption: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#333333' },
+    subtextNormal: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.5, color: '#7f7f7f' },
+    subtextWhite: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.5, color: '#FFFFFF' },
+    toggleNormal: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#7f7f7f' },
+    togglePrimary: { fontSize: '0.75rem', fontWeight: 400, lineHeight: 1.2, color: '#1B6FD3' },
+  },
+}


### PR DESCRIPTION
# RPT-3728: Migrate frontend from sample_fe_vite

This PR migrates the frontend from the sample_fe_vite repository to the raas-next-sample repository.

## Changes
- Added necessary dependencies (raas-react-client and datatraveler-react-client)
- Migrated all page components to Next.js App Router structure
- Adapted API client functions to work with Next.js
- Migrated custom hooks and themes
- Configured environment variables for Next.js

## Testing
- Verified all pages load correctly
- Verified navigation between pages works
- Verified component rendering works

Link to Devin run: https://app.devin.ai/sessions/8288185234584226ba94653022be740d
Requested by: Sunao Suzuki (sunao@sutech.co.jp)
