### PR TITLE
RPT-3728: Fix backend URL for API requests

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -48,7 +48,11 @@ const createReportSession = async (subUrl: string): Promise<Session> => {
 }
 
 const createRaasSession = async (msa: 'datatraveler' | 'report', subUrl: string): Promise<Session> => {
-  return await fetch(BACKEND_URL + `/api/raas/${msa}/session`, {
+  const apiUrl = BACKEND_URL?.endsWith('/api') 
+    ? `${BACKEND_URL}/raas/${msa}/session`
+    : `${BACKEND_URL}/api/raas/${msa}/session`;
+    
+  return await fetch(apiUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -48,7 +48,7 @@ const createReportSession = async (subUrl: string): Promise<Session> => {
 }
 
 const createRaasSession = async (msa: 'datatraveler' | 'report', subUrl: string): Promise<Session> => {
-  return await fetch(BACKEND_URL + `/raas/${msa}/session`, {
+  return await fetch(BACKEND_URL + `/api/raas/${msa}/session`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
# RPT-3728: Fix backend URL for API requests

This PR fixes the issue where the dictionary page doesn't display due to 404 errors by updating the API endpoint paths to correctly handle the `/api` prefix in BACKEND_URL.

## Changes
- Modified the createRaasSession function in src/api/index.ts to check if BACKEND_URL already ends with `/api` before adding it
- This ensures frontend requests are sent to the correct endpoint regardless of the BACKEND_URL configuration
- Prevents double `/api` prefix issues when BACKEND_URL includes `/api` in .env.local

## Testing
- Verified the API requests now return 200 status codes instead of 404 errors
- Confirmed in server logs that requests to `/api/raas/report/session` are successful

## Notes
- There's a Next.js warning about using `params.msa` synchronously in the API route handler that could be addressed in a future PR

Link to Devin run: https://app.devin.ai/sessions/8288185234584226ba94653022be740d
Requested by: Sunao Suzuki (sunao@sutech.co.jp)
